### PR TITLE
chore: Add additional thumbprint for OIDC cert

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -112,11 +112,18 @@
       {
         "type": "Hex High Entropy String",
         "filename": "modules/open-id-connect/open_id_connect.tf",
+        "hashed_secret": "1583f84aecd79812f156ed914a879c2607c116bf",
+        "is_verified": false,
+        "line_number": 4
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "modules/open-id-connect/open_id_connect.tf",
         "hashed_secret": "cbc1f47e57ba98544b156d9f7d45542e9475686f",
         "is_verified": false,
         "line_number": 4
       }
     ]
   },
-  "generated_at": "2023-03-29T15:25:44Z"
+  "generated_at": "2023-07-06T11:46:47Z"
 }

--- a/modules/open-id-connect/open_id_connect.tf
+++ b/modules/open-id-connect/open_id_connect.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_openid_connect_provider" "tre_github_actions" {
   url             = "https://token.actions.githubusercontent.com"
   client_id_list  = ["sts.amazonaws.com"]
-  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1", "1c58a3a8518e8759bf075b76b750d4f2df264fcd"]
 }


### PR DESCRIPTION
Adding extra thumbprint as https://github.blog/changelog/2023-06-27-github-actions-update-on-oidc-integration-with-aws/

Updating detect secrets as it thinks it's a secret