### PR TITLE
Use customer managed kms key for sample data bucket

### DIFF
--- a/modules/sample-data/s3.tf
+++ b/modules/sample-data/s3.tf
@@ -7,7 +7,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "da_transform_samp
   bucket = aws_s3_bucket.da_transform_sample_data.id
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm = "aws:kms"
+      kms_master_key_id = "alias/s3/platform/da-transform-sample-data"
+      sse_algorithm     = "aws:kms"
     }
   }
 }


### PR DESCRIPTION
The sample data s3 bucket must use customer managed key
Added policy manually 
this should update with terraform