### PR TITLE
DTE 811 add prod arn to roles that can be assumed

### DIFF
--- a/modules/v2-github-action-testing/v2_github_action_testing_roles.tf
+++ b/modules/v2-github-action-testing/v2_github_action_testing_roles.tf
@@ -1,10 +1,10 @@
 resource "aws_iam_role" "v2_github_action_testing" {
-  name               = "${var.prefix}-v2-github-action-testing"
+  name               = var.name
   assume_role_policy = data.aws_iam_policy_document.v2_github_action_testing.json
 }
 
 resource "aws_iam_policy" "v2_github_action_testing" {
-  name = "${var.prefix}-v2-github-action-testing"
+  name = var.name
   policy = templatefile(var.v2_github_action_testing_policy_path, {
     aws_region  = var.aws_region
     account_id  = var.account_id

--- a/modules/v2-github-action-testing/variables.tf
+++ b/modules/v2-github-action-testing/variables.tf
@@ -1,3 +1,8 @@
+variable "name" {
+  description = "Name for create policies and roles"
+  type        = string
+}
+
 variable "prefix" {
   description = "Prefix for transformation engine resources"
   type        = string

--- a/tf-backend/locals.tf
+++ b/tf-backend/locals.tf
@@ -41,7 +41,8 @@ locals {
       policy_path = "./templates/open-id-connect-role-policy/v2-github-action-testing.tftpl"
       tf_state    = "" # Testing does not require any tf_state access
       roles_can_assume = [
-        module.nonprod_v2_github_action_testing_roles.tre_v2_github_action_testing_role_arn
+        module.nonprod_v2_github_action_testing_roles.tre_v2_github_action_testing_role_arn,
+        module.prod_v2_github_action_testing_roles.tre_v2_github_action_testing_role_arn
       ]
     }
   ]
@@ -100,6 +101,7 @@ locals {
   tre_policies_managed_by_tf_backend_nonprod = [
     module.tre_nonprod_terraform_roles.tre_terraform_iam_policy,
     module.tre_nonprod_terraform_roles.tre_terraform_policy,
+    module.tre_nonprod_terraform_roles.tre_permission_boundary,
     "arn:aws:iam::${data.aws_caller_identity.nonprod.account_id}:policy/${local.v2-github-testing-resources-name}",
     "arn:aws:iam::${data.aws_caller_identity.nonprod.account_id}:policy/${var.prefix}-terraform-backend"
   ]

--- a/tf-backend/locals.tf
+++ b/tf-backend/locals.tf
@@ -94,7 +94,7 @@ locals {
   tre_roles_managed_by_tf_backend_nonprod = [
     module.tre_nonprod_terraform_roles.tre_terraform_backend_role_arn,
     module.tre_nonprod_terraform_roles.terraform_role_arn,
-    "arn:aws:iam::${data.aws_caller_identity.nonprod.account_id}:role/${local.v2-github-testing-resources-name}",
+    "arn:aws:iam::${data.aws_caller_identity.nonprod.account_id}:role/${local.v2-github-testing-resources-name}"
   ]
 
   tre_policies_managed_by_tf_backend_nonprod = [
@@ -107,7 +107,7 @@ locals {
   tre_roles_managed_by_tf_backend_prod = [
     module.tre_prod_terraform_roles.tre_terraform_backend_role_arn,
     module.tre_prod_terraform_roles.terraform_role_arn,
-    "arn:aws:iam::${data.aws_caller_identity.prod.account_id}:role/${local.v2-github-testing-resources-name}",
+    "arn:aws:iam::${data.aws_caller_identity.prod.account_id}:role/${local.v2-github-testing-resources-name}"
   ]
 
   tre_policies_managed_by_tf_backend_prod = [

--- a/tf-backend/locals.tf
+++ b/tf-backend/locals.tf
@@ -94,26 +94,29 @@ locals {
   tre_roles_managed_by_tf_backend_nonprod = [
     module.tre_nonprod_terraform_roles.tre_terraform_backend_role_arn,
     module.tre_nonprod_terraform_roles.terraform_role_arn,
-    module.nonprod_v2_github_action_testing_roles.tre_v2_github_action_testing_role_arn
+    "arn:aws:iam::${data.aws_caller_identity.nonprod.account_id}:role/${local.v2-github-testing-resources-name}",
   ]
 
   tre_policies_managed_by_tf_backend_nonprod = [
     module.tre_nonprod_terraform_roles.tre_terraform_iam_policy,
     module.tre_nonprod_terraform_roles.tre_terraform_policy,
-    module.tre_nonprod_terraform_roles.tre_permission_boundary,
-    module.nonprod_v2_github_action_testing_roles.tre_v2_github_action_testing_policy_arn,
+    "arn:aws:iam::${data.aws_caller_identity.nonprod.account_id}:policy/${local.v2-github-testing-resources-name}",
     "arn:aws:iam::${data.aws_caller_identity.nonprod.account_id}:policy/${var.prefix}-terraform-backend"
   ]
 
   tre_roles_managed_by_tf_backend_prod = [
     module.tre_prod_terraform_roles.tre_terraform_backend_role_arn,
-    module.tre_prod_terraform_roles.terraform_role_arn
+    module.tre_prod_terraform_roles.terraform_role_arn,
+    "arn:aws:iam::${data.aws_caller_identity.prod.account_id}:role/${local.v2-github-testing-resources-name}",
   ]
 
   tre_policies_managed_by_tf_backend_prod = [
     module.tre_prod_terraform_roles.tre_terraform_iam_policy,
     module.tre_prod_terraform_roles.tre_terraform_policy,
     module.tre_prod_terraform_roles.tre_permission_boundary,
+    "arn:aws:iam::${data.aws_caller_identity.prod.account_id}:policy/${local.v2-github-testing-resources-name}",
     "arn:aws:iam::${data.aws_caller_identity.prod.account_id}:policy/${var.prefix}-terraform-backend"
   ]
+  
+  v2-github-testing-resources-name = "${var.prefix}-v2-github-action-testing"
 }

--- a/tf-backend/main.tf
+++ b/tf-backend/main.tf
@@ -66,6 +66,7 @@ module "tre_prod_terraform_roles" {
 
 # Roles grant access to GitHub action to execute tests
 module "nonprod_v2_github_action_testing_roles" {
+  name                                           = local.v2-github-testing-resources-name
   source                                         = "../modules/v2-github-action-testing"
   prefix                                         = var.prefix
   aws_region                                     = data.aws_region.management.name
@@ -75,9 +76,11 @@ module "nonprod_v2_github_action_testing_roles" {
   providers = {
     aws = aws.nonprod
   }
+  depends_on = [ module.tre_nonprod_terraform_roles ]
 }
 
 module "prod_v2_github_action_testing_roles" {
+  name                                           = local.v2-github-testing-resources-name
   source                                         = "../modules/v2-github-action-testing"
   prefix                                         = var.prefix
   aws_region                                     = data.aws_region.management.name
@@ -87,4 +90,5 @@ module "prod_v2_github_action_testing_roles" {
   providers = {
     aws = aws.prod
   }
+  depends_on = [ module.tre_prod_terraform_roles ]
 }


### PR DESCRIPTION
- fix: Construct arns under backend role management from names
- Remove trailing commas
- fix: Add prod arn to roles that can be assumed by openid connect
