### PR TITLE
DTE-855: disable versioning in sample data bucket

### DIFF
--- a/modules/sample-data/s3.tf
+++ b/modules/sample-data/s3.tf
@@ -16,7 +16,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "da_transform_samp
 resource "aws_s3_bucket_versioning" "da_transform_sample_data" {
   bucket = aws_s3_bucket.da_transform_sample_data.id
   versioning_configuration {
-    status = "Enabled"
+    status = "Disabled"
   }
 }
 


### PR DESCRIPTION
Really to be able to test platform approval stage in pipeline, but seems good to not version sample data anyway so won't revert if this works.